### PR TITLE
Clarify intentions and which activities considered harassment

### DIFF
--- a/incident-reporting.md
+++ b/incident-reporting.md
@@ -17,8 +17,10 @@ Reports of Code of Conduct violations should include as many details as possible
 - Additional context
 - If it is ongoing
 
-The Algolia Community prioritizes marginalized people’s safety over privileged people’s comfort. Our moderators will not act on reports regarding:
-- “Reverse”-isms, including “reverse racism,” “reverse sexism,” and “cisphobia.”
+The Algolia Community prioritizes the inclusion and welcoming of marginalized people.
+
+Our moderators will not act on reports regarding:
+- Good faith and non-malicious conduct whose object is to improve the conditions of disadvantaged individuals or groups including those that are disadvantaged because of race, national or ethnic origin, colour, religion, sex, gender identity, sexual orientation, physical appearance, body size, age or mental or physical disability.
 - Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
 - Verbal communication in a tone you don’t find pleasant (try focusing on responding to the content or disengaging instead).
 - Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions.

--- a/incident-reporting.md
+++ b/incident-reporting.md
@@ -17,10 +17,9 @@ Reports of Code of Conduct violations should include as many details as possible
 - Additional context
 - If it is ongoing
 
-The Algolia Community prioritizes the inclusion and welcoming of marginalized people.
+The Algolia Community prioritizes the safety and inclusion of marginalized people.
 
 Our moderators will not act on reports regarding:
-- Good faith and non-malicious conduct whose object is to improve the conditions of disadvantaged individuals or groups including those that are disadvantaged because of race, national or ethnic origin, colour, religion, sex, gender identity, sexual orientation, physical appearance, body size, age or mental or physical disability.
 - Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”
 - Verbal communication in a tone you don’t find pleasant (try focusing on responding to the content or disengaging instead).
 - Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions.


### PR DESCRIPTION
This change does two things:
- Clarify intentions when it comes to which activities will not be acted upon
- Remove language that creates opposition where it doesn't add significant value

Inspired partially from: https://github.com/todogroup/opencodeofconduct/pull/68. I didn't use his suggestion on sanctioning a complaint, because, while I agree that bad faith complaints are something to be avoided, we have no indication yet that they are a problem in the community and placing it there proactively could have a chilling effect in the case where someone would need to report harassment.

For the clarification on intentions, I am of course making assumptions on what the originally intentions are and could be wrong, but I think that this reads better and more clearly. It clarifies that there are occasions where prioritizing disadvantaged people is acceptable (and we will not act against) without shutting out completely the possibility that there are situations where it could be genuine harassment.

This new language further reinforces our commitment to improving the condition of disadvantaged people.

For the second part, I tweaked it to remove language of opposition where none need exist. Comfort and inclusion need not be in opposition and with the existing language, I think we indicate that it must. Nonetheless, we do prioritize inclusion over non-inclusion.

Please shoot with feedback and critiques. 😃 
